### PR TITLE
feat: add optimistic user message display for instant UX

### DIFF
--- a/src/features/chat/hooks/use-display-messages.ts
+++ b/src/features/chat/hooks/use-display-messages.ts
@@ -1,3 +1,4 @@
+import { useEffect, useMemo } from "react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { api } from "@/convex/_generated/api";
 import { useStreamingAssistant } from "./use-streaming-assistant";
@@ -22,14 +23,24 @@ export function useDisplayMessages(
   );
 
   // Get streaming message and pending user message (always call hook, but pass empty string if no threadId)
-  const { streamingMessage, pendingUserMessage } = useStreamingAssistant(
-    threadId ?? "",
-  );
+  const { streamingMessage, pendingUserMessage, clearPendingUserMessage } =
+    useStreamingAssistant(threadId ?? "");
 
   // Convert Convex messages to UI messages
-  const convexUIMessages = convexMessages
-    ? convexMessagesToUIMessages(convexMessages)
-    : [];
+  const convexUIMessages = useMemo(
+    () => (convexMessages ? convexMessagesToUIMessages(convexMessages) : []),
+    [convexMessages],
+  );
+
+  // Clear pending user message when it appears in Convex
+  useEffect(() => {
+    if (
+      pendingUserMessage &&
+      convexUIMessages.some((m) => m.id === pendingUserMessage.id)
+    ) {
+      clearPendingUserMessage();
+    }
+  }, [pendingUserMessage, convexUIMessages, clearPendingUserMessage]);
 
   // Build base messages
   let messages = convexUIMessages;

--- a/src/features/chat/hooks/use-display-messages.ts
+++ b/src/features/chat/hooks/use-display-messages.ts
@@ -40,7 +40,8 @@ export function useDisplayMessages(
     ) {
       clearPendingUserMessage();
     }
-  }, [pendingUserMessage, convexUIMessages, clearPendingUserMessage]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingUserMessage?.id, convexUIMessages, clearPendingUserMessage]);
 
   // Build base messages
   let messages = convexUIMessages;

--- a/src/features/chat/hooks/use-streaming-assistant.ts
+++ b/src/features/chat/hooks/use-streaming-assistant.ts
@@ -21,6 +21,7 @@ export function useStreamingAssistant(
 ): {
   streamingMessage: MyUIMessage | null;
   pendingUserMessage: MyUIMessage | null;
+  clearPendingUserMessage: () => void;
 } {
   const { throttleMs } = options || {};
 
@@ -70,8 +71,14 @@ export function useStreamingAssistant(
     },
   );
 
+  const clearPendingUserMessage = useCallback(() => {
+    const store = getOrCreateStreamingStore(threadId);
+    if (store) store.pendingUserMessage = null;
+  }, [threadId]);
+
   return {
     streamingMessage,
     pendingUserMessage,
+    clearPendingUserMessage,
   };
 }

--- a/src/features/chat/send-message.ts
+++ b/src/features/chat/send-message.ts
@@ -76,7 +76,9 @@ const sendMessageEffect = ({
     const { userMessage, assistantMessage, messagesForConvex } =
       yield* createMessagesToAdd(content, selectedModel);
 
-    // Immediately write seed message to store so it's available on interrupt
+    // Set pending user message for optimistic UI (before Convex sync)
+    store.pendingUserMessage = userMessage;
+    // Set assistant message ready for streaming
     store.message = assistantMessage;
 
     // Create thread if it's a new thread
@@ -87,6 +89,8 @@ const sendMessageEffect = ({
         model: selectedModel,
         messages: messagesForConvex,
       });
+      // Clear pending user message - now in Convex
+      store.pendingUserMessage = null;
     }
 
     // Fetch thread messages for history
@@ -103,6 +107,8 @@ const sendMessageEffect = ({
         threadId,
         messages: messagesForConvex,
       });
+      // Clear pending user message - now in Convex/optimistic
+      store.pendingUserMessage = null;
     }
 
     const result = yield* makeRequest({

--- a/src/features/chat/send-message.ts
+++ b/src/features/chat/send-message.ts
@@ -89,8 +89,6 @@ const sendMessageEffect = ({
         model: selectedModel,
         messages: messagesForConvex,
       });
-      // Clear pending user message - now in Convex
-      store.pendingUserMessage = null;
     }
 
     // Fetch thread messages for history
@@ -107,8 +105,6 @@ const sendMessageEffect = ({
         threadId,
         messages: messagesForConvex,
       });
-      // Clear pending user message - now in Convex/optimistic
-      store.pendingUserMessage = null;
     }
 
     const result = yield* makeRequest({
@@ -156,6 +152,8 @@ const sendMessageEffect = ({
       Effect.sync(() => {
         console.error("Error occurred:", error);
         store.status = "error";
+        // Clear pending user message on error to prevent stuck state
+        store.pendingUserMessage = null;
       }),
     ),
   );


### PR DESCRIPTION
     Eliminates flicker when creating new threads by showing pending user
     message immediately before Convex sync completes.

     Changes:
     - Add pendingUserMessage to StreamingMessageStore for optimistic display
     - Update send-message.ts to set/clear pending user message around Convex mutations
     - Expose pendingUserMessage in use-streaming-assistant hook
     - Update use-display-messages to show pending user with duplicate prevention

     Result: Instant message appearance on submit with seamless transition to
     Convex data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Shows your typed message immediately as a “pending” message and exposes a clear action to reset it.
  - Pending message state is now available to the streaming assistant so UI can reflect it reliably.

- Improvements
  - Smarter message ordering: pending message + streaming reply take priority, placeholders are replaced in place, and duplicates are avoided.
  - Optimistic send behavior: pending message appears instantly and is cleared on error for more reliable chat interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->