### PR TITLE
gen and regen

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as actions from "../actions.js";
 import type * as auth from "../auth.js";
 import type * as email from "../email.js";
 import type * as emails_reset_password_email from "../emails/reset_password_email.js";
@@ -36,6 +37,7 @@ import type {
  * ```
  */
 declare const fullApi: ApiFromModules<{
+  actions: typeof actions;
   auth: typeof auth;
   email: typeof email;
   "emails/reset_password_email": typeof emails_reset_password_email;

--- a/convex/actions.ts
+++ b/convex/actions.ts
@@ -1,0 +1,108 @@
+"use node";
+
+import { action } from "./_generated/server";
+import { v } from "convex/values";
+import { generateText, convertToModelMessages, validateUIMessages } from "ai";
+import { api } from "./_generated/api";
+import type { MessageParts } from "./schema/messages";
+
+/**
+ * Generates a thread title based on the first user message.
+ * Uses gemini-2.0-flash-lite for fast, cheap title generation.
+ * Runs on Convex server to keep API key secure.
+ */
+export const generateTitle = action({
+  args: {
+    message: v.any(),
+  },
+  handler: async (ctx, args) => {
+    // Validate the UI message first
+    const validatedMessages = await validateUIMessages({
+      messages: [args.message],
+    });
+    const message = validatedMessages[0];
+
+    // Generate title with AI
+    const result = await generateText({
+      model: "google/gemini-2.0-flash-lite",
+      system: `You will generate a short title based on the first message a user begins a conversation with.
+- Ensure it is not more than 80 characters long
+- The title should be a summary of the user's message
+- Do not use quotes or colons
+- DO NOT use any markdown
+- DO NOT use any emojis
+- DO NOT use any special characters
+- DO NOT use any numbers
+- DO NOT use any punctuation`,
+      messages: convertToModelMessages([message]),
+    });
+
+    return result.text.trim();
+  },
+});
+
+/**
+ * Regenerates a thread title based on all messages in the thread.
+ * Uses gemini-2.0-flash-lite for fast, cheap title generation.
+ * Runs on Convex server to keep API key secure.
+ */
+export const regenerateTitle = action({
+  args: {
+    threadId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    // Get all messages for the thread
+    const messages = await ctx.runQuery(api.messages.getThreadMessages, {
+      threadId: args.threadId,
+    });
+
+    if (!messages || messages.length === 0) {
+      throw new Error("No messages found for thread");
+    }
+
+    // Format messages for title generation
+    const formatMessageContent = (parts: MessageParts) => {
+      return parts
+        .map((part) => {
+          if (part.type === "text" && "text" in part) {
+            return part.text;
+          }
+          if (part.type === "reasoning" && "text" in part) {
+            return `**Reasoning:**\n${part.text}`;
+          }
+          return "";
+        })
+        .filter(Boolean)
+        .join("\n\n");
+    };
+
+    const conversationText = messages
+      .map((message) => {
+        const content = formatMessageContent(message.parts);
+        const roleLabel = message.role === "user" ? "USER" : "ASSISTANT";
+        return `${roleLabel}:\n${content}`;
+      })
+      .join("\n\n==========\n\n");
+
+    // Generate title with AI based on all messages
+    const result = await generateText({
+      model: "google/gemini-2.0-flash-lite",
+      prompt: `You will generate a short title based on the entire conversation in this thread.
+- Ensure it is not more than 80 characters long
+- The title should be a summary of the main topic or theme of the conversation
+- Do not use quotes or colons
+- DO NOT use any markdown
+- DO NOT use any emojis
+- DO NOT use any special characters
+- DO NOT use any numbers
+- DO NOT use any punctuation
+
+Conversation:
+${conversationText}`,
+    });
+
+    const title: string = result.text.trim();
+
+    return title;
+  },
+});

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,16 @@
+import { Loader2Icon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    />
+  );
+}
+
+export { Spinner };

--- a/src/features/chat/hooks/use-convex-functions.ts
+++ b/src/features/chat/hooks/use-convex-functions.ts
@@ -368,15 +368,17 @@ export function useConvexFunctions() {
       Effect.retry({ times: 1 }),
       Effect.catchAll(() => {
         // Fallback: extract first 40 chars from message text
-        const textContent = message.parts
+        const fullTextContent = message.parts
           .filter((part) => part.type === "text")
           .map((part) => part.text)
-          .join(" ")
-          .slice(0, 40);
+          .join(" ");
 
-        const fallbackTitle = textContent + "...";
+        const textContent =
+          fullTextContent.length > 40
+            ? fullTextContent.slice(0, 40) + "..."
+            : fullTextContent;
 
-        return Effect.succeed(fallbackTitle);
+        return Effect.succeed(textContent);
       }),
     );
 

--- a/src/features/chat/send-message.ts
+++ b/src/features/chat/send-message.ts
@@ -89,6 +89,18 @@ const sendMessageEffect = ({
         model: selectedModel,
         messages: messagesForConvex,
       });
+
+      // Fork effect to generate title and update thread
+      yield* Effect.fork(
+        convexFunctions.actions.generateTitle(userMessage).pipe(
+          Effect.flatMap((title) =>
+            convexFunctions.mutations.updateThreadTitle({
+              threadId,
+              title,
+            }),
+          ),
+        ),
+      );
     }
 
     // Fetch thread messages for history

--- a/src/features/sidebar/components/thread-item.tsx
+++ b/src/features/sidebar/components/thread-item.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/context-menu";
 import { useThreadActions } from "../hooks/use-thread-actions";
 import { DeleteThreadDialog } from "./delete-thread-dialog";
+import { Spinner } from "@/components/ui/spinner";
 
 import type { ThreadItemData } from "../types";
 
@@ -46,6 +47,7 @@ export function ThreadItem({
     setEditTitle,
     showDeleteDialog,
     isDeleting,
+    isRegeneratingTitle,
     inputRef,
     isSwitchingToEditRef,
     startEditing,
@@ -131,6 +133,7 @@ export function ThreadItem({
                       onDoubleClick={handleDoubleClick}
                     >
                       <div className="relative w-full flex items-center">
+                        {isRegeneratingTitle && <Spinner />}
                         <Input
                           ref={inputRef}
                           id={`thread-title-${item.id}`}
@@ -229,7 +232,7 @@ export function ThreadItem({
             Rename
           </ContextMenuItem>
           <ContextMenuItem onClick={handleRegenerateTitle}>
-            <Sparkles />
+            {isRegeneratingTitle ? <Spinner /> : <Sparkles />}
             Regenerate Title
           </ContextMenuItem>
           <ContextMenuItem onClick={handleContextMenuDelete}>

--- a/src/features/sidebar/components/thread-item.tsx
+++ b/src/features/sidebar/components/thread-item.tsx
@@ -231,7 +231,10 @@ export function ThreadItem({
             <TextCursor className="text-muted-foreground" />
             Rename
           </ContextMenuItem>
-          <ContextMenuItem onClick={handleRegenerateTitle}>
+          <ContextMenuItem
+            onClick={handleRegenerateTitle}
+            disabled={isRegeneratingTitle}
+          >
             {isRegeneratingTitle ? <Spinner /> : <Sparkles />}
             Regenerate Title
           </ContextMenuItem>

--- a/src/features/sidebar/hooks/use-thread-actions.ts
+++ b/src/features/sidebar/hooks/use-thread-actions.ts
@@ -202,6 +202,7 @@ export function useThreadActions(threadId: string) {
   const handleDeleteOpenChange = (open: boolean) => setShowDeleteDialog(open);
 
   const handleRegenerateTitle = async () => {
+    if (isRegeneratingTitle) return;
     try {
       setIsRegeneratingTitle(true);
       const newTitle = await regenerateTitle({ threadId });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic thread title generation for new conversations (derived from first message).
  - One-click “Regenerate Title” that derives a title from the full conversation.
  - Non-blocking background title generation so thread creation isn’t delayed.

- UX/Behavior
  - Optimistic title updates for snappier sidebar refresh.
  - Graceful fallback: uses a short preview if title generation fails.
  - Regeneration locked to prevent concurrent runs.

- UI
  - Loading spinner shown while regenerating titles (next to title and in menu).
  - Success and error toasts for title updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->